### PR TITLE
Fixed binstrings by keeping track of index properly

### DIFF
--- a/binstrings.py
+++ b/binstrings.py
@@ -11,18 +11,21 @@ from itertools import *
 for i in range(10):
     combs = product([0,1], repeat=2*i+1)
     ks = [0 for i in range(2*i + 2)]
-
+    
     for comb in combs:
         i_in_a_row = 0
         bad = False
+        ind = 0
         for element in comb:
             if element == 1:
                 i_in_a_row += 1
             elif element == 0:
                 i_in_a_row = 0
             
-            if (i_in_a_row == 3 and i % 2 != 0) or i_in_a_row > 3:
+            if (i_in_a_row == 3 and ind % 2 == 0) or i_in_a_row > 3:
                 bad = True
+                break # we don't need to keep testing at this point
+            ind += 1
         
         if not bad:
             ks[sum(comb)] += 1        


### PR DESCRIPTION
I accidentally used the value to calculate n instead of the index to check if the 3 bit string starts on an even index. Now, index is kept track of separately which allows the computation to be done correctly.